### PR TITLE
Collect system info on Windows and Linux

### DIFF
--- a/cli_tracker/sdk.py
+++ b/cli_tracker/sdk.py
@@ -31,14 +31,33 @@ class CliTracker:
                 "arch": mac[2]
             })
         elif os_name == "Linux":
-            desktop = platform.freedesktop_os_release()
+            py_ver = platform.python_version_tuple()
+            if (int(py_ver[0]) >= 3 and int(py_ver[1]) >= 10):
+                name = platform.freedesktop_os_release()['ID']
+                try:
+                    version = platform.freedesktop_os_release()['VERSION_ID']
+                except:
+                    # Most likely this distribution is a rolling release
+                    # distribution and has no version information
+                    version = None
+                arch = platform.machine()
+            else:
+                # This is some support for python versions below 3.10
+                import distro
+                name = distro.id()
+                version = distro.version()
+                arch = platform.machine()
             sentry_sdk.set_context("os", {
-                "name": "macOS",
-                "version": mac[0], # TODO Georg
-                "arch": mac[2]
+                "name": name,
+                "version": version,
+                "arch": arch
             })
         elif os_name == "Windows":
-            pass
+            sentry_sdk.set_context("os", {
+                "name": "Windows",
+                "version": platform.release(),
+                "arch": platform.machine()
+            })
         else:
             pass
         sentry_sdk.set_context("os", {

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "distro"
+version = "1.7.0"
+description = "Distro - an OS platform information API"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "sentry-sdk"
 version = "1.5.12"
 description = "Python client for Sentry (https://sentry.io)"
@@ -52,12 +60,16 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5039a740aec01d11e41cf123ece2090b5d286deac5fcef0730225211dbe287d9"
+content-hash = "fcc37f34cd42a0c31d7508e1a09d040f9b076ac20962c18479a230010c3b527c"
 
 [metadata.files]
 certifi = [
     {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
     {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+]
+distro = [
+    {file = "distro-1.7.0-py3-none-any.whl", hash = "sha256:d596311d707e692c2160c37807f83e3820c5d539d5a83e87cfb6babd8ba3a06b"},
+    {file = "distro-1.7.0.tar.gz", hash = "sha256:151aeccf60c216402932b52e40ee477a939f8d58898927378a02abbe852c1c39"},
 ]
 sentry-sdk = [
     {file = "sentry-sdk-1.5.12.tar.gz", hash = "sha256:259535ba66933eacf85ab46524188c84dcb4c39f40348455ce15e2c0aca68863"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ authors = ["Robert Stein <robert@blueshoe.de>", "Georg Krause <georg@blueshoe.de
 [tool.poetry.dependencies]
 python = "^3.8"
 sentry-sdk = "^1.5.12"
+# only required for python < 3.10 on linux
+distro = { version = "^1.7.0", markers = "sys_platform == 'linux'" } 
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This needs verification to work on Windows.

@SteinRobert Do you agree with the linux way to gather the information? Python version 3.8 and 3.9 don't seem to have relieable builtins to get distribution information, but 3.10 has. So my intention is to get rid of the dependency as soon as python 3.9 is EOL (05 Oct 2025). Alternatively we can just use the third-party lib everywhere. 